### PR TITLE
fix: :bug: fix the swap__recreate_swap_file fact to make it compatible with ansible-core 2.19/ansible 12

### DIFF
--- a/tasks/enable-swap-file.yml
+++ b/tasks/enable-swap-file.yml
@@ -16,7 +16,7 @@
 
 - name: Set the swap__recreate_swap_file fact
   ansible.builtin.set_fact:
-    swap__recreate_swap_file: "{{ (swap__file_size | replace('M', '')) != swap__existing_swap_file_size }}"
+    swap__recreate_swap_file: "{{ (swap__file_size | replace('M', '') | int) != swap__existing_swap_file_size }}"
   when: swap__file_status.stat.exists
 
 - name: Check swap file condition


### PR DESCRIPTION
# Ansible 11

Until Ansible 11, the `swap__existing_swap_file_size` fact was being set as `AnsibleUnsafeText`:

```
- name: Set the swap__existing_swap_file_size fact
  ansible.builtin.set_fact:
    swap__existing_swap_file_size: "{{ (swap__file_status.stat.size / 1024 / 1024) | int }}"
```

```
- debug:
    msg: "{{ swap__existing_swap_file_size | type_debug }}"
```

```
TASK [ansible-role-swap : debug] ***********************************************
ok: [debian-12] => {
    "msg": "AnsibleUnsafeText"
}
```

The above allowed the comparison below to work as expected, since the comparison was happening between values of type `AnsibleUnsafeText` and `str`:

```
- name: Set the swap__recreate_swap_file fact
  ansible.builtin.set_fact:
    swap__recreate_swap_file: "{{ (swap__file_size | replace('M', '')) != swap__existing_swap_file_size }}"
```

---

# Ansible 12

In Ansible 12, the `swap__existing_swap_file_size` fact is now being set as `int`:

```
- name: Set the swap__existing_swap_file_size fact
  ansible.builtin.set_fact:
    swap__existing_swap_file_size: "{{ (swap__file_status.stat.size / 1024 / 1024) | int }}"
```

```
- debug:
    msg: "{{ swap__existing_swap_file_size | type_debug }}"
```

```
TASK [ansible-role-swap : debug] ***********************************************
ok: [debian-12] => {
    "msg": "int"
}
```

The above explains why in Ansible 12 the comparison below breaks: It breaks because the comparison happens between values of type `int` and `str`. Details below:

```
- name: Set the swap__recreate_swap_file fact
  ansible.builtin.set_fact:
    swap__recreate_swap_file: "{{ (swap__file_size | replace('M', '')) != swap__existing_swap_file_size }}"
```

---

# Fix

To fix this - thus making this Ansible role compatible with Ansible 12 - one can simply change the above to what can be seen below, which then allows the comparison to work properly since it is happening between two values of type `int`:

```
- name: Set the swap__recreate_swap_file fact
  ansible.builtin.set_fact:
    swap__recreate_swap_file: "{{ (swap__file_size | replace('M', '') | int) != swap__existing_swap_file_size }}"
```

This PR implements the change and documents the reason why it had to be done.